### PR TITLE
Update CoreOS demo to reference Powerstrip archive branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Set up Calico on CoreOS using Vagrant
 
->*Note that Calico's use of powerstrip support (as seen in this demo) is being replaced by Docker's new [libnetwork network driver support](https://github.com/docker/libnetwork) available in the Docker [experimental channel](https://github.com/docker/docker/tree/master/experimental) alongside the Docker 1.7 release.  You can find the Calico libnetwork demo [here](https://github.com/Metaswitch/calico-ubuntu-vagrant)*
+>*Note that Calico's use of powerstrip support (as seen in this demo) is being replaced by Docker's new [libnetwork network driver support](https://github.com/docker/libnetwork) available in the Docker [experimental channel](https://github.com/docker/docker/tree/master/experimental) alongside the Docker 1.7 release.  You can find the latest Calico libnetwork demo on the main [Getting Started page](https://github.com/Metaswitch/calico-docker/blob/master/docs/GettingStarted.md).*
 
 You can quickly set up a CoreOS cluster ready to network Docker containers with <a href="https://github.com/Metaswitch/calico-docker">Calico Docker networking</a> using the Vagrant files in this repo.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Set up Calico on CoreOS using Vagrant
 
+>*Note that Calico's use of powerstrip support (as seen in this demo) is being replaced by Docker's new [libnetwork network driver support](https://github.com/docker/libnetwork) available in the Docker [experimental channel](https://github.com/docker/docker/tree/master/experimental) alongside the Docker 1.7 release.  You can find the Calico libnetwork demo [here](https://github.com/Metaswitch/calico-ubuntu-vagrant)*
+
 You can quickly set up a CoreOS cluster ready to network Docker containers with <a href="https://github.com/Metaswitch/calico-docker">Calico Docker networking</a> using the Vagrant files in this repo.
 
 This repo is a preconfigured fork of the <a href="https://github.com/coreos/coreos-vagrant">sample CoreOS Vagrant configuration</a> with the following changes:
@@ -82,7 +84,7 @@ Follow the step by step [getting started instructions][using-calico] in the main
 [virtualbox]: https://www.virtualbox.org/
 [vagrant]: https://www.vagrantup.com/downloads.html
 [using-coreos]: http://coreos.com/docs/using-coreos/
-[using-calico]: https://github.com/Metaswitch/calico-docker/blob/master/docs/GettingStarted.md
+[using-calico]: https://github.com/Metaswitch/calico-docker/blob/powerstrip-archive/docs/GettingStarted.md
 [git]: http://git-scm.com/
 
 ## Additional optional setup steps


### PR DESCRIPTION
With Calico-docker now using libnetwork, the main getting started page has been updated.  CoreOS still does not have a Docker image that supports libnetwork, so keep powerstrip references available.